### PR TITLE
dx: prevent frustration from accidental npm use

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preinstall": "npx -y only-allow pnpm"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.5.1",
@@ -29,5 +30,9 @@
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
     "vite-plugin-node-polyfills": "^0.8.2"
+  },
+  "prettier": {
+    "src": "@github/prettier-config",
+    "printWidth": 100
   }
 }


### PR DESCRIPTION
https://pnpm.io/only-allow-pnpm

I don't know how this works... but it works flawlessly  so Im not complaining. Yes I tested performance, it's indistinguisable when using pnpm, and only causes a minor hickup when running npm... rather than a minute of corruption and turmoil