### PR TITLE
Pull to refresh bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "pnpm": {
     "overrides": {
-      "dockview-core": "https://pkg.csb.dev/mathuo/dockview/commit/bc5f8208/dockview-core"
+      "dockview-core": "https://pkg.csb.dev/mathuo/dockview/commit/2156a1dd/dockview-core"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 overrides:
-  dockview-core: https://pkg.csb.dev/mathuo/dockview/commit/bc5f8208/dockview-core
+  dockview-core: https://pkg.csb.dev/mathuo/dockview/commit/2156a1dd/dockview-core
 
 dependencies:
   '@monaco-editor/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1019,7 +1019,7 @@ packages:
   /dockview@1.7.3:
     resolution: {integrity: sha512-GGtaC0pTRX3nTa5XGUEIXInZf71COYsld25ricAptxlAMiuMH+zbVrZJQnvx2KeItahhEejPQ1sThd4u7jzzqQ==}
     dependencies:
-      dockview-core: '@pkg.csb.dev/mathuo/dockview/commit/bc5f8208/dockview-core'
+      dockview-core: '@pkg.csb.dev/mathuo/dockview/commit/2156a1dd/dockview-core'
     dev: false
 
   /domain-browser@4.22.0:
@@ -1830,7 +1830,7 @@ packages:
     dev: true
 
   '@pkg.csb.dev/mathuo/dockview/commit/bc5f8208/dockview-core':
-    resolution: {tarball: https://pkg.csb.dev/mathuo/dockview/commit/bc5f8208/dockview-core}
+    resolution: {tarball: https://pkg.csb.dev/mathuo/dockview/commit/2156a1dd/dockview-core}
     name: dockview-core
     version: 1.7.3
     dev: false

--- a/src/index.css
+++ b/src/index.css
@@ -20,12 +20,11 @@
   }
 }
 
-html { overscroll-behavior: none; } /* disable pull to refresh */
-
 body, html, #root {
   width: 100%;
   height: 100%;
   margin: 0;
+  overscroll-behavior: none; /* no pull to refresh. Safari needs html, Chrome body. */
 }
 
 iframe {

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,8 @@
   }
 }
 
+html { overscroll-behavior: none; } /* disable pull to refresh */
+
 body, html, #root {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Pull to refresh was interfering with touch resizing of terminal

Change is automatically live on https://vslite.42x.app as it's hosted on github pages, with Cloudflare's firewall merely adding the headers, and no staging step. vslite.dev is missing the mobile update completely.

fyi, I am not able to merge to default branch without your review...