### PR TITLE
tree fix for cloning post boot

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -83,7 +83,7 @@ class TreeProvider<T = any> implements RCT.TreeDataProvider {
   public async updateItems(items: Record<RCT.TreeItemIndex, RCT.TreeItem<T>>) {
     debug('updateItems items', items)
     this.data = {items};
-    this.onDidChangeTreeDataEmitter.emit(['root']);
+    this.onDidChangeTreeDataEmitter.emit(Object.keys(items));
   }
 
   public async getTreeItem(itemId: RCT.TreeItemIndex): Promise<RCT.TreeItem> {

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -62,7 +62,7 @@ export function FileTree(props: FileTreeProps) {
           getItemTitle={item => item.data}
           onPrimaryAction={item => props.onTriggerItem(item.index.toString(), item.data)}
           onRenameItem={(item, name) => props.onRenameItem(item.index.toString(), name)}
-          onExpandItem={(item) => {debug('expand', item); FileTreeState.refresh()}}
+          // onExpandItem={(item) => {debug('expand', item)}}
           viewState={{filetree: {}}}>
           <Tree treeId="filetree" treeLabel="Explorer" rootItem="root"/>
         </UncontrolledTreeEnvironment>

--- a/src/hooks/useShell.ts
+++ b/src/hooks/useShell.ts
@@ -61,6 +61,8 @@ export function useShell(): ShellInstance {
         } else if (data.includes('Watching "."')) {
           debug('File watcher ready.');
           watchReady = true;
+        } else {
+          debug('chokidar: ', data)
         }
         switch (type) {
           case 'change':

--- a/src/modules/webcontainer.ts
+++ b/src/modules/webcontainer.ts
@@ -25,7 +25,7 @@ export async function getDirAsTree(
 
   if (parent === 'root') db.root = root;
 
-  directory.forEach(item => {
+  for (const item of directory) {
     const isDir = item.isDirectory();
     const itemPath = `${path}/${item.name}`;
     db[itemPath] = {
@@ -37,8 +37,8 @@ export async function getDirAsTree(
       children: [],
     };
     if (parent) db?.[parent]?.children?.push(itemPath);
-    if (isDir) return getDirAsTree(fs, itemPath, itemPath, root, db);
-  });
+    if (isDir) await getDirAsTree(fs, itemPath, itemPath, root, db);
+  };
 
   debug('getDirAsTree() db', db);
 


### PR DESCRIPTION
Changes:

- Refactor forEach, used while mutating in an Async func could lead to unpredictable results
- Notify Tree subscribers of changes to any files/folders.
