### PR TITLE
Add support for loading / saving .env

### DIFF
--- a/src/hooks/useShell.ts
+++ b/src/hooks/useShell.ts
@@ -51,6 +51,13 @@ export function useShell(): ShellInstance {
     await shell.spawn('mv', ['.jshrc', '/home/.jshrc']);
     shell.mount(startFiles);
 
+    // Get .env from localStorage
+    const configRaw = localStorage.getItem('vslite_config');
+    const config = configRaw ? JSON.parse(configRaw) : {};
+    if (config?.env) {
+      await shell.fs.writeFile('.env', config.env);
+    }
+
     // Setup terminal
     const terminal = new Terminal({convertEol: true, theme});
     const addon = new FitAddon();
@@ -62,7 +69,10 @@ export function useShell(): ShellInstance {
     const watch = await shell.spawn('npx', ['-y', 'chokidar-cli', '.', '-i', '"(**/(node_modules|.git|_tmp_)**)"']);
     watch.output.pipeTo(new WritableStream({
       async write(data) {
-        const type: string = data.split(':').at(0) || ''
+        // Check if it is .env and read it into local storage
+        if (data.match(/\.env/))
+          await loadEnv(shell, data);
+        const type: string = data.split(':').at(0) || '';
         if (watchReady) {
           debug('Change detected: ', data);
         } else if (data.includes('Watching "."')) {
@@ -121,4 +131,24 @@ export function useShell(): ShellInstance {
   }, []);
 
   return { terminal, container, process, start };
+}
+
+async function loadEnv(shell: WebContainer, data: string) { 
+  const configRaw = globalThis.localStorage?.vslite_config;
+  let config = configRaw ? JSON.parse(configRaw) : {};
+  debug('.env changed', data);
+  try {
+    const bContents = await shell.fs.readFile('.env');
+    const sContents = new TextDecoder().decode(bContents);
+    debug('contents', sContents);
+    if(!config) config = {};
+    config.env = sContents;
+    localStorage.setItem('vslite_config', JSON.stringify(config));
+  } catch(e) {
+    if (config?.env) {
+      delete config.env;
+      localStorage.setItem('vslite_config', JSON.stringify(config));        
+    }
+    debug('.env file deleted', e);
+  }
 }


### PR DESCRIPTION
@FossPrime when you get time would it be possible to add prompting and loading of a config file as suggested by @rhildred.

These are his suggested changes, here is the relevant code from his git fork:

https://github.com/search?q=repo%3Adiy-pwa%2Fgit-pwa%20.env&type=code

I'm also open to the Secrets API.